### PR TITLE
Use filename in vault path.

### DIFF
--- a/event/csv_handler.go
+++ b/event/csv_handler.go
@@ -84,7 +84,11 @@ func (handler CSVHandler) Handle(event *DimensionsInserted) error {
 
 	var output *s3.GetObjectOutput
 	if handler.vaultClient != nil {
-		pskStr, err := handler.vaultClient.ReadKey(handler.vaultPath, filename)
+
+		vaultPath := handler.vaultPath + "/" + filename
+		vaultKey := "key"
+
+		pskStr, err := handler.vaultClient.ReadKey(vaultPath, vaultKey)
 		if err != nil {
 			return err
 		}

--- a/event/csv_handler_test.go
+++ b/event/csv_handler_test.go
@@ -60,7 +60,7 @@ func TestSuccessfullyHandleCSV(t *testing.T) {
 				psk := []byte("Hello World")
 				path := "test-path"
 
-				vaultClient.EXPECT().ReadKey(path, filename).Return(encodedPSK, nil)
+				vaultClient.EXPECT().ReadKey(path + "/" + filename, "key").Return(encodedPSK, nil)
 
 				s3GetOutput := &s3.GetObjectOutput{
 					Body: ioutil.NopCloser(strings.NewReader(exampleHeader + "\n" + exampleCsvLine)),
@@ -127,7 +127,7 @@ func TestFailToHandleCSV(t *testing.T) {
 				path := "test-path"
 				testErr := errors.New("vault client error")
 
-				vaultClient.EXPECT().ReadKey(path, filename).Return("", testErr)
+				vaultClient.EXPECT().ReadKey(path + "/" + filename, "key").Return("", testErr)
 
 				csvHandler := event.NewCSVHandler(nil, nil, vaultClient, nil, path)
 
@@ -146,7 +146,7 @@ func TestFailToHandleCSV(t *testing.T) {
 				path := "test-path"
 				invalidPSK := "this-is-not-hex-encoded"
 
-				vaultClient.EXPECT().ReadKey(path, filename).Return(invalidPSK, nil)
+				vaultClient.EXPECT().ReadKey(path + "/" + filename, "key").Return(invalidPSK, nil)
 
 				csvHandler := event.NewCSVHandler(nil, nil, vaultClient, nil, path)
 
@@ -169,7 +169,7 @@ func TestFailToHandleCSV(t *testing.T) {
 				path := "test-path"
 				testErr := errors.New("crypto client error")
 
-				vaultClient.EXPECT().ReadKey(path, filename).Return(encodedPSK, nil)
+				vaultClient.EXPECT().ReadKey(path + "/" + filename, "key").Return(encodedPSK, nil)
 
 				client.EXPECT().GetObjectWithPSK(getInput, psk).Return(nil, testErr)
 

--- a/policy.hcl
+++ b/policy.hcl
@@ -1,3 +1,3 @@
-path "secret/shared/psk" {
+path "secret/shared/psk/*" {
   capabilities = ["read"]
 }


### PR DESCRIPTION
### What

* Use filename in vaultpath

Intentionally merging into `feature/psk-decryption` as its where the initial decryption code exists. Requires the branch of the same name for florence and dp-dimension-exporter.
