### PR TITLE
Fix/dp kafka v2.4.3

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -53,7 +53,7 @@ func getDefaultConfig() *Config {
 		HealthCheckInterval:     30 * time.Second,
 		HealthCriticalTimeout:   90 * time.Second,
 		KafkaConfig: KafkaConfig{
-			Brokers:                  []string{"localhost:9092"},
+			Brokers:                  []string{"localhost:9092", "localhost:9093", "localhost:9094"},
 			Version:                  "1.0.2",
 			OffsetOldest:             true,
 			SecProtocol:              "",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -33,7 +33,7 @@ func TestSpec(t *testing.T) {
 					HealthCheckInterval:     30 * time.Second,
 					HealthCriticalTimeout:   90 * time.Second,
 					KafkaConfig: config.KafkaConfig{
-						Brokers:                  []string{"localhost:9092"},
+						Brokers:                  []string{"localhost:9092", "localhost:9093", "localhost:9094"},
 						Version:                  "1.0.2",
 						OffsetOldest:             true,
 						SecProtocol:              "",

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/ONSdigital/dp-healthcheck v1.1.3
-	github.com/ONSdigital/dp-kafka/v2 v2.4.2
+	github.com/ONSdigital/dp-kafka/v2 v2.4.3
 	github.com/ONSdigital/dp-reporter-client v1.1.0
 	github.com/ONSdigital/dp-s3 v1.6.0
 	github.com/ONSdigital/dp-vault v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf
 github.com/ONSdigital/dp-healthcheck v1.1.3 h1:i9WV6BNdZFoefHCxmPle2OunNHUd8WnUqkDdK0OXhZU=
 github.com/ONSdigital/dp-healthcheck v1.1.3/go.mod h1:Wu3Um1Dd99K9rH41KfeCvuw8dxgVGsghj0tzT+yp8So=
 github.com/ONSdigital/dp-kafka/v2 v2.0.2/go.mod h1:iyDeWxp1QyJJBQ4cOCWuwrwU9iGS9qYbfV7avbcaenI=
-github.com/ONSdigital/dp-kafka/v2 v2.4.2 h1:Wur0nzhqcyEsS+W02OukjxvdzJ3hYeIqy/ySdXk+44w=
-github.com/ONSdigital/dp-kafka/v2 v2.4.2/go.mod h1:W7BZ0zUmIuOMne18Pe3I4V/nF41Ynwy0N5A4+s7ahaw=
+github.com/ONSdigital/dp-kafka/v2 v2.4.3 h1:Sb5nc4M3RsDMDmclsTqyjTMP6IBD7dRkv3kaIM26LLs=
+github.com/ONSdigital/dp-kafka/v2 v2.4.3/go.mod h1:W7BZ0zUmIuOMne18Pe3I4V/nF41Ynwy0N5A4+s7ahaw=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:BcIRgitUju//qgNePRBmNjATarTtynAgc0yV29VpLEk=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805082802-e518bc287596/go.mod h1:wDVhk2pYosQ1q6PXxuFIRYhYk2XX5+1CeRRnXpSczPY=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805145012-9227a11caddb/go.mod h1:MrSZwDUvp8u1VJEqa+36Gwq4E7/DdceW+BDCvGes6Cs=


### PR DESCRIPTION
### What

- Upgrade `dp-kafka` dependency to v2.4.3 to use the healthcheck fix where kafka producers/consumers will have a `warning` health (instead of `critical`) if enough brokers are available
  - min 2 brokers for producers
  - min 1 broker for consumers
- kafkaAddr match brokers in dp-compose

### How to review

Make sure `dp-kafka` dependency is upgraded

### Who can review

anyone